### PR TITLE
Update Chrome HSTS Preload link

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -27,7 +27,7 @@
 
   <h1>Welcome to HSTSPreload.com!</h1>
   <p>This is an API that allows applications to easily check to see if a site is included on the Chrome, Firefox, and Tor <a href="https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security">HSTS</a> Preload lists.
-    To add your site to HSTS Preload lists, you can do so via the <a href="https://hstspreload.appspot.com/">Chrome HSTS Preload</a> site; most other browsers base their HSTS Preload list on the list maintained by Chrome.</p>
+    To add your site to HSTS Preload lists, you can do so via the <a href="https://hstspreload.org/">Chrome HSTS Preload</a> site; most other browsers base their HSTS Preload list on the list maintained by Chrome.</p>
   <p>The API is designed to be as easy to use as possible:</p>
   <p><code>curl https://hstspreload.com/api/v1/status/<strong>google.com</strong></code></p>
   <p><code>{"domain":"google.com","chrome":{"present":true,"include_subdomains":true,"last_updated":1474098192},"firefox":null,"tor":null}</code></p>


### PR DESCRIPTION
The Appspot link that has been previously provided currently redirects to a domain in the org TLD, which is also what you see when doing Google searches for the site. We can just refer to this .org instead of doing the extra redirect via the previous .appspot.com domain.